### PR TITLE
🐛 fix(xendit): correct balance unit conversion

### DIFF
--- a/src/lib/providers/xendit/client.ts
+++ b/src/lib/providers/xendit/client.ts
@@ -334,9 +334,11 @@ export class XenditFinancialProvider implements FinancialProvider {
       throw new ProviderValidationError('Xendit did not return a cash balance.', 502);
     }
 
+    const currency = cashBalance.currency ?? 'PHP';
+
     return {
-      availableMinor: cashBalance.balance,
-      currency: cashBalance.currency ?? 'PHP',
+      availableMinor: amountToMinorUnits(cashBalance.balance, currency),
+      currency,
       fetchedAt: new Date(),
       raw: cashBalance,
     };

--- a/src/lib/providers/xendit/schemas.ts
+++ b/src/lib/providers/xendit/schemas.ts
@@ -20,7 +20,7 @@ const xenditRawAccountSchema = z.object({
 }).passthrough();
 
 const xenditRawBalanceSchema = z.object({
-  balance: bigintLikeSchema,
+  balance: decimalLikeSchema,
   currency: z.string().min(1).optional(),
   type: z.string().min(1).optional(),
   account_type: z.string().min(1).optional(),


### PR DESCRIPTION
Correct the handling of account balances from the Xendit API. Xendit returns balances as decimal values, but the provider was previously treating them as minor units.

- Update balance schema to use decimal parsing instead of bigint
- Convert decimal amounts to minor units using currency utility
- Default to PHP currency when calculating minor units